### PR TITLE
Update Global.scala

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,12 +1,15 @@
 import play.api._
 import org.anormcypher._
 import java.net.URL
+import util._
 
 object Global extends GlobalSettings {
 
   override def onStart(app: Application) {
     Logger.info("configuring Neo4j for " + System.getenv("GRAPHENEDB_URL"))
-    val url = new URL(System.getenv("GRAPHENEDB_URL"))
+    val neo4jURLString = util.Properties.envOrElse("GRAPHENEDB_URL","http://localhost:7474")
+    val url:URL = new URL(neo4jURLString)
+
     // testing locally don't have user/pass
     if(url.getUserInfo != null) {
       val Array(user:String, pass:String) = url.getUserInfo.split(":")
@@ -15,5 +18,4 @@ object Global extends GlobalSettings {
       Neo4jREST.setServer(url.getHost, url.getPort, "/db/data/")
     }
   }
-
 }


### PR DESCRIPTION
With these changes it is possible to run the project with `activator run` without declaring the environment variable `GRAPHENEDB_URL`...
